### PR TITLE
Инкремент 1. Разработать сервер для сбора рантайм-метрик.

### DIFF
--- a/.github/workflows/mertricstest.yml
+++ b/.github/workflows/mertricstest.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check branch names
+      - name: Check branch name
         run: |
           if [[ ! $GITHUB_HEAD_REF =~ ^iter[0-9]+$ ]] && [[ ${{ github.ref }} != "refs/heads/main" ]]; then echo "Branch name must match pattern 'iter<number>' or github.ref must be 'refs/heads/main'" && echo "Your branch is $GITHUB_HEAD_REF and github.ref is ${{ github.ref }}" && exit 1; else echo "Your branch is $GITHUB_HEAD_REF and github.ref is ${{ github.ref }}"; fi
 

--- a/internal/agent/poll_test.go
+++ b/internal/agent/poll_test.go
@@ -1,0 +1,40 @@
+/*
+ * This file was last modified at 2024-02-12 20:47 by Victor N. Skurikhin.
+ * poll_test.go
+ * $Id$
+ */
+
+package agent
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vskurikhin/gometrics/internal/storage/memory"
+	"github.com/vskurikhin/gometrics/internal/types"
+	"runtime"
+	"testing"
+)
+
+func TestPoll(t *testing.T) {
+
+	memStats := new(runtime.MemStats)
+	memStorage := memory.Instance()
+
+	var tests = []struct {
+		name  string
+		input []types.Name
+		want  string
+	}{
+		{name: "positive test #0", input: []types.Name{types.Alloc}, want: "Alloc"},
+		{name: "positive test #1", input: []types.Name{types.GCCPUFraction}, want: "GCCPUFraction"},
+		{name: "positive test #2", input: []types.Name{types.NumForcedGC}, want: "NumForcedGC"},
+		{name: "positive test #3", input: []types.Name{types.PollCount}, want: "PollCount"},
+		{name: "positive test #4", input: []types.Name{types.RandomValue}, want: "RandomValue"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			poll(test.input, memStats, memStorage)
+			got := memStorage.Get(test.want)
+			assert.NotNil(t, got)
+		})
+	}
+}

--- a/internal/agent/report_test.go
+++ b/internal/agent/report_test.go
@@ -1,0 +1,42 @@
+/*
+ * This file was last modified at 2024-02-12 21:05 by Victor N. Skurikhin.
+ * report_test.go
+ * $Id$
+ */
+
+package agent
+
+import (
+	"github.com/vskurikhin/gometrics/internal/env"
+	"github.com/vskurikhin/gometrics/internal/storage/memory"
+	"github.com/vskurikhin/gometrics/internal/types"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReport(t *testing.T) {
+
+	env.InitAgent()
+	server := httptest.NewServer(
+		http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}),
+	)
+	defer server.Close()
+
+	client := server.Client()
+	memStorage := memory.Instance()
+
+	var tests = []struct {
+		name   string
+		input1 []types.Name
+		input2 string
+		want   string
+	}{
+		{name: "positive test #0", input1: []types.Name{types.Alloc}, input2: "0", want: "Alloc"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			report(test.input1, memStorage, client)
+		})
+	}
+}

--- a/internal/env/agent_env_test.go
+++ b/internal/env/agent_env_test.go
@@ -1,0 +1,58 @@
+/*
+ * This file was last modified at 2024-02-11 17:31 by Victor N. Skurikhin.
+ * agent_env_test.go
+ * $Id$
+ */
+
+package env
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestAgentEnvURLHost(t *testing.T) {
+	urlHost := "localhost:8080"
+	var tests = []struct {
+		name  string
+		input agentEnv
+		want  string
+		want1 time.Duration
+		want2 time.Duration
+	}{
+		{name: "Test URLHost() positive #0",
+			input: agentEnv{
+				serverEnv:      serverEnv{serverAddress: &urlHost},
+				reportInterval: time.Duration(10),
+				pollInterval:   time.Duration(2),
+			},
+			want:  "http://localhost:8080",
+			want1: time.Duration(10),
+			want2: time.Duration(2),
+		},
+		{name: "Test URLHost() positive #1",
+			input: agentEnv{
+				serverEnv:      serverEnv{serverAddress: &urlHost},
+				urlHost:        &urlHost,
+				reportInterval: time.Duration(11),
+				pollInterval:   time.Duration(3),
+			},
+			want:  "localhost:8080",
+			want1: time.Duration(11),
+			want2: time.Duration(3),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.URLHost()
+			fmt.Printf("got: %v\n", *got)
+			assert.Equal(t, test.want, *got)
+			got1 := test.input.ReportInterval()
+			assert.Equal(t, test.want1, got1)
+			got2 := test.input.PollInterval()
+			assert.Equal(t, test.want2, got2)
+		})
+	}
+}

--- a/internal/env/agent_flags_test.go
+++ b/internal/env/agent_flags_test.go
@@ -1,0 +1,60 @@
+/*
+ * This file was last modified at 2024-02-11 17:31 by Victor N. Skurikhin.
+ * agent_flags_test.go
+ * $Id$
+ */
+
+package env
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestAgentFlagsURLHost(t *testing.T) {
+	urlHost := "localhost:8080"
+	reportInterval := time.Duration(10)
+	pollInterval := time.Duration(2)
+	var tests = []struct {
+		name  string
+		input agentFlags
+		want  string
+		want1 time.Duration
+		want2 time.Duration
+	}{
+		{name: "Test URLHost() positive #0",
+			input: agentFlags{
+				serverFlags:    serverFlags{serverAddress: &urlHost},
+				reportInterval: &reportInterval,
+				pollInterval:   &pollInterval,
+			},
+			want:  "http://localhost:8080",
+			want1: time.Duration(10),
+			want2: time.Duration(2),
+		},
+		{name: "Test URLHost() positive #1",
+			input: agentFlags{
+				serverFlags:    serverFlags{serverAddress: &urlHost},
+				urlHost:        &urlHost,
+				reportInterval: &reportInterval,
+				pollInterval:   &pollInterval,
+			},
+			want:  "localhost:8080",
+			want1: time.Duration(10),
+			want2: time.Duration(2),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.URLHost()
+			fmt.Printf("got: %v\n", *got)
+			assert.Equal(t, test.want, *got)
+			got1 := test.input.ReportInterval()
+			assert.Equal(t, test.want1, got1)
+			got2 := test.input.PollInterval()
+			assert.Equal(t, test.want2, got2)
+		})
+	}
+}

--- a/internal/env/init.go
+++ b/internal/env/init.go
@@ -1,5 +1,5 @@
 /*
- * This file was last modified at 2024-02-10 23:59 by Victor N. Skurikhin.
+ * This file was last modified at 2024-02-11 17:04 by Victor N. Skurikhin.
  * init.go
  * $Id$
  */
@@ -22,11 +22,12 @@ var (
 	Server = serverEnv{}
 )
 
+var cfg config
+
 func InitAgent() {
 
 	initAgentFlags()
 
-	var cfg config
 	err := env.Parse(&cfg)
 	if err != nil {
 		log.Fatal(err)

--- a/internal/env/init_agent_test.go
+++ b/internal/env/init_agent_test.go
@@ -1,0 +1,43 @@
+/*
+ * This file was last modified at 2024-02-11 17:08 by Victor N. Skurikhin.
+ * init_agent_test.go
+ * $Id$
+ */
+
+package env
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestInitAgentWithEnv(t *testing.T) {
+	old := cfg
+	urlHost := "localhost:8080"
+	arrHost := []string{"localhost", "8080"}
+	var tests = []struct {
+		name  string
+		input config
+		want  agentEnv
+	}{
+		{
+			name:  "Test Parse() function for PollCount with type: parser",
+			input: config{Address: arrHost, ReportInterval: 10, PollInterval: 2},
+			want: agentEnv{
+				serverEnv:      serverEnv{serverAddress: &urlHost},
+				reportInterval: time.Duration(10),
+				pollInterval:   time.Duration(2),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg = test.input
+			InitAgent()
+			//fmt.Printf("urlHost: %s\n", *Agent.urlHost)
+			assert.Equal(t, test.want, Agent)
+		})
+	}
+	cfg = old
+}

--- a/internal/env/server_env_test.go
+++ b/internal/env/server_env_test.go
@@ -1,0 +1,34 @@
+/*
+ * This file was last modified at 2024-02-11 17:36 by Victor N. Skurikhin.
+ * server_env_test.go
+ * $Id$
+ */
+
+package env
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestServerEnvServerAddress(t *testing.T) {
+	urlHost := "localhost:8080"
+	var tests = []struct {
+		name  string
+		input serverEnv
+		want  string
+	}{
+		{name: "Test URLHost() positive #0",
+			input: serverEnv{
+				serverAddress: &urlHost,
+			},
+			want: "localhost:8080",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.ServerAddress()
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/env/server_flags_test.go
+++ b/internal/env/server_flags_test.go
@@ -1,0 +1,34 @@
+/*
+ * This file was last modified at 2024-02-11 17:36 by Victor N. Skurikhin.
+ * server_flags_test.go
+ * $Id$
+ */
+
+package env
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestServerFlagsServerAddress(t *testing.T) {
+	urlHost := "localhost:8080"
+	var tests = []struct {
+		name  string
+		input serverFlags
+		want  string
+	}{
+		{name: "Test URLHost() positive #0",
+			input: serverFlags{
+				serverAddress: &urlHost,
+			},
+			want: "localhost:8080",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.ServerAddress()
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/handlers/update_handler_test.go
+++ b/internal/handlers/update_handler_test.go
@@ -1,0 +1,136 @@
+/*
+ * This file was last modified at 2024-02-11 15:11 by Victor N. Skurikhin.
+ * update_handler_test.go
+ * $Id$
+ */
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vskurikhin/gometrics/api/names"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUpdateHandler(t *testing.T) {
+	type want struct {
+		code        int
+		response    string
+		contentType string
+	}
+	tests := []struct {
+		name     string
+		input    string
+		type_    string
+		variable string
+		want     want
+	}{
+		{
+			name:     "positive test #1",
+			input:    "1.1",
+			type_:    "gauge",
+			variable: "Alloc",
+			want: want{
+				code:        200,
+				response:    "",
+				contentType: "",
+			},
+		},
+		{
+			name:     "negative test #1",
+			input:    "1.1",
+			type_:    "",
+			variable: "Alloc",
+			want: want{
+				code:        400,
+				response:    "",
+				contentType: "",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			w := httptest.NewRecorder()
+			target := fmt.Sprintf("%s%s/%s/%s", names.UpdateURL, test.type_, test.variable, test.input)
+			r := httptest.NewRequest(http.MethodPost, target, nil)
+
+			rctx := chi.NewRouteContext()
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			UpdateHandler(w, r)
+
+			res := w.Result()
+			assert.Equal(t, test.want.code, res.StatusCode)
+			//goland:noinspection GoUnhandledErrorResult
+			defer res.Body.Close()
+			resBody, err := io.ReadAll(res.Body)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want.response, string(resBody))
+			assert.Equal(t, test.want.contentType, res.Header.Get("Content-Type"))
+		})
+	}
+}
+
+func TestUpdateHandlerNegative(t *testing.T) {
+	oldStorage := storage
+	type want struct {
+		code        int
+		response    string
+		contentType string
+	}
+	tests := []struct {
+		name     string
+		input    string
+		type_    string
+		variable string
+		want     want
+	}{
+		{
+			name:     "negative test #0",
+			input:    "1.1",
+			type_:    "gauge",
+			variable: "Alloc",
+			want: want{
+				code:        404,
+				response:    "",
+				contentType: "",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			w := httptest.NewRecorder()
+			target := fmt.Sprintf("%s%s/%s/%s", names.UpdateURL, test.type_, test.variable, test.input)
+			r := httptest.NewRequest(http.MethodPost, target, nil)
+
+			rctx := chi.NewRouteContext()
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			storage = nil
+			UpdateHandler(w, r)
+
+			res := w.Result()
+			assert.Equal(t, test.want.code, res.StatusCode)
+			//goland:noinspection GoUnhandledErrorResult
+			defer res.Body.Close()
+			resBody, err := io.ReadAll(res.Body)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want.response, string(resBody))
+			assert.Equal(t, test.want.contentType, res.Header.Get("Content-Type"))
+		})
+	}
+	storage = oldStorage
+}

--- a/internal/handlers/value_handler.go
+++ b/internal/handlers/value_handler.go
@@ -1,5 +1,5 @@
 /*
- * This file was last modified at 2024-02-11 00:04 by Victor N. Skurikhin.
+ * This file was last modified at 2024-02-11 15:02 by Victor N. Skurikhin.
  * value_handler.go
  * $Id$
  */
@@ -27,6 +27,7 @@ func ValueHandler(response http.ResponseWriter, request *http.Request) {
 		} else {
 			value = storage.Get(name)
 		}
+
 		response.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		if value == nil {
 			response.WriteHeader(http.StatusNotFound)

--- a/internal/handlers/value_handler_test.go
+++ b/internal/handlers/value_handler_test.go
@@ -1,0 +1,110 @@
+/*
+ * This file was last modified at 2024-02-11 14:52 by Victor N. Skurikhin.
+ * value_handler_test.go
+ * $Id$
+ */
+
+package handlers
+
+import (
+	"context"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vskurikhin/gometrics/api/names"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestValueHandler(t *testing.T) {
+	type want struct {
+		code        int
+		response    string
+		contentType string
+	}
+	tests := []struct {
+		name     string
+		input    string
+		type_    string
+		variable string
+		want     want
+	}{
+		{
+			name:     "positive test #0",
+			input:    "0.1",
+			type_:    "gauge",
+			variable: "_none",
+			want: want{
+				code:        200,
+				response:    "0.1\n",
+				contentType: "text/plain; charset=utf-8",
+			},
+		},
+		{
+			name:     "positive test #1",
+			input:    "1.1",
+			type_:    "gauge",
+			variable: "Alloc",
+			want: want{
+				code:        200,
+				response:    "1.1\n",
+				contentType: "text/plain; charset=utf-8",
+			},
+		},
+		{
+			name:     "negative test #0",
+			input:    "1.1",
+			type_:    "counter",
+			variable: "Alloc",
+			want: want{
+				code:        404,
+				response:    "",
+				contentType: "",
+			},
+		},
+		{
+			name:     "negative test #1",
+			input:    "",
+			type_:    "counter",
+			variable: "_none",
+			want: want{
+				code:        404,
+				response:    "",
+				contentType: "text/plain; charset=utf-8",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, names.ValueURL+"{type}/{name}", nil)
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("type", test.type_)
+			rctx.URLParams.Add("name", test.variable)
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			if test.input != "" {
+				storage.Put(test.variable, &test.input)
+			} else {
+				storage.Put(test.variable, nil)
+			}
+
+			ValueHandler(w, r)
+
+			res := w.Result()
+			assert.Equal(t, test.want.code, res.StatusCode)
+			//goland:noinspection GoUnhandledErrorResult
+			defer res.Body.Close()
+			resBody, err := io.ReadAll(res.Body)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want.response, string(resBody))
+			assert.Equal(t, test.want.contentType, res.Header.Get("Content-Type"))
+		})
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,5 +1,5 @@
 /*
- * This file was last modified at 2024-02-11 00:21 by Victor N. Skurikhin.
+ * This file was last modified at 2024-02-11 15:55 by Victor N. Skurikhin.
  * parser.go
  * $Id$
  */
@@ -103,21 +103,16 @@ func (p *parser) CalcValue(get *string) *string {
 		return &p.originalValue
 	case int:
 		o := typeAssertionInt(old)
-		if o == nil {
-			return &p.originalValue
-		}
-		result := fmt.Sprintf("%d", v+*o)
+		result := fmt.Sprintf("%d", v+o)
 		return &result
-	default:
-		return nil
 	}
+	return nil
 }
 
-func typeAssertionInt(i interface{}) *int {
+func typeAssertionInt(i interface{}) int {
 	switch o := i.(type) {
 	case int:
-		return &o
-	default:
-		return nil
+		return o
 	}
+	return 0
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,5 +1,5 @@
 /*
- * This file was last modified at 2024-02-11 00:38 by Victor N. Skurikhin.
+ * This file was last modified at 2024-02-11 15:51 by Victor N. Skurikhin.
  * parser_test.go
  * $Id$
  */
@@ -7,10 +7,12 @@
 package parser
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/vskurikhin/gometrics/internal/types"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 )
 
@@ -33,7 +35,7 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
-			"Test String() method for GCCPUFraction with type parser",
+			"Test Parse() method for GCCPUFraction with type parser",
 			"/update/gauge/gccpufraction/676524.874",
 			parser{
 				type_:         types.GAUGE,
@@ -44,6 +46,33 @@ func TestParser(t *testing.T) {
 				httpStatus:    http.StatusOK,
 			},
 		},
+		{
+			"positive test #0",
+			"/update/gauge/nil/676524.874",
+			parser{
+				type_:         types.GAUGE,
+				number:        0,
+				name:          "nil",
+				originalValue: "676524.874",
+				parsedValue:   float64(676524.874),
+				httpStatus:    http.StatusOK,
+			},
+		},
+		{
+			"negative test #0",
+			"",
+			parser{httpStatus: http.StatusNotFound},
+		},
+		{
+			"negative test #1",
+			"/update/nil/nil/0",
+			parser{httpStatus: http.StatusBadRequest},
+		},
+		{
+			"negative test #3",
+			"/update/gauge/nil/a",
+			parser{httpStatus: http.StatusBadRequest},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -53,10 +82,143 @@ func TestParser(t *testing.T) {
 					Path: test.input,
 				},
 			}
-			test.want.request = r
+			if test.want.httpStatus == http.StatusOK {
+				test.want.request = r
+			}
 			got, err := Parse(r)
-			assert.Nil(t, err)
+			if test.want.httpStatus == http.StatusOK {
+				assert.Nil(t, err)
+			}
 			assert.Equal(t, test.want, *got)
 		})
 	}
+}
+
+func TestString(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input parser
+		want  string
+	}{
+		{
+			"Test String() function for PollCount with type: parser",
+			parser{name: "PollCount"},
+			"PollCount",
+		},
+		{
+			"Test String() method for GCCPUFraction with type parser",
+			parser{name: "GCCPUFraction"},
+			"GCCPUFraction",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.String()
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestValue(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input parser
+		want  interface{}
+	}{
+		{
+			"Test Value() function for PollCount with type: parser",
+			parser{parsedValue: 31},
+			31,
+		},
+		{
+			"Test Value() method for GCCPUFraction with type parser",
+			parser{parsedValue: float64(676524.874)},
+			float64(676524.874),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.Value()
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input parser
+		want  int
+	}{
+		{
+			"Test Status() function for PollCount with type: parser",
+			parser{httpStatus: 200},
+			http.StatusOK,
+		},
+		{
+			"Test Status() method for GCCPUFraction with type parser",
+			parser{httpStatus: 404},
+			http.StatusNotFound,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.Status()
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestCalcValue(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input parser
+		old   string
+		want  string
+	}{
+		{
+			"Test Parse() function for PollCount with type: parser",
+			parser{
+				type_:         types.COUNTER,
+				number:        types.PollCount,
+				name:          "PollCount",
+				originalValue: "31",
+				parsedValue:   int(31),
+				httpStatus:    http.StatusOK,
+			},
+			"11",
+			"42",
+		},
+		{
+			"Test Parse() method for GCCPUFraction with type parser",
+			parser{
+				type_:         types.GAUGE,
+				number:        types.GCCPUFraction,
+				name:          "GCCPUFraction",
+				originalValue: "676524.874",
+				parsedValue:   float64(676524.874),
+				httpStatus:    http.StatusOK,
+			},
+			"676524.741",
+			"676524.874",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.CalcValue(&test.old)
+			assert.Equal(t, test.want, *got)
+		})
+	}
+	t.Run("negative test #2", func(t *testing.T) {
+		p := parser{originalValue: "test"}
+		got := p.CalcValue(nil)
+		assert.Equal(t, "test", *got)
+	})
+	t.Run("negative test #3", func(t *testing.T) {
+		p := parser{originalValue: "test"}
+		x := "x"
+		got := p.CalcValue(&x)
+		fmt.Fprintf(os.Stderr, "got: %v\n", got)
+		assert.Nil(t, got)
+	})
 }

--- a/internal/storage/memory/mem_storage.go
+++ b/internal/storage/memory/mem_storage.go
@@ -1,5 +1,5 @@
 /*
- * This file was last modified at 2024-02-08 21:41 by Victor N. Skurikhin.
+ * This file was last modified at 2024-02-11 13:51 by Victor N. Skurikhin.
  * mem_storage.go
  * $Id$
  */
@@ -11,14 +11,14 @@ import (
 )
 
 type MemStorage struct {
-	mu      sync.RWMutex
-	Metrics map[string]*string
+	sync.RWMutex
+	metrics map[string]*string
 }
 
 var mem = new(MemStorage)
 
 func init() {
-	mem.Metrics = make(map[string]*string)
+	mem.metrics = make(map[string]*string)
 }
 
 func Instance() *MemStorage {
@@ -27,15 +27,15 @@ func Instance() *MemStorage {
 
 func (m *MemStorage) Get(name string) *string {
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.RLock()
+	defer m.RUnlock()
 
-	return m.Metrics[name]
+	return m.metrics[name]
 }
 
 func (m *MemStorage) Put(name string, value *string) {
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.Metrics[name] = value
+	m.Lock()
+	defer m.Unlock()
+	m.metrics[name] = value
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,17 +1,13 @@
 /*
- * This file was last modified at 2024-02-11 00:04 by Victor N. Skurikhin.
+ * This file was last modified at 2024-02-12 20:43 by Victor N. Skurikhin.
  * storage.go
  * $Id$
  */
 
 package storage
 
-import (
-	"github.com/vskurikhin/gometrics/internal/types"
-)
-
 type Storage interface {
-	Get(name types.Name) (interface{}, error)
+	Get(name string) *string
 
-	Put(name types.Name, value interface{}) error
+	Put(name string, value *string)
 }

--- a/internal/util/format_request_test.go
+++ b/internal/util/format_request_test.go
@@ -1,5 +1,5 @@
 /*
- * This file was last modified at 2024-02-04 17:13 by Victor N. Skurikhin.
+ * This file was last modified at 2024-02-11 21:27 by Victor N. Skurikhin.
  * format_request_test.go
  * $Id$
  */
@@ -14,16 +14,29 @@ import (
 )
 
 func TestFormatRequest(t *testing.T) {
+	headers := map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}}
 	var tests = []struct {
-		input string
-		want  string
+		input  string
+		method string
+		header map[string][]string
+		want   string
 	}{
-		{"", "  \nHost: "},
-		{"a", " a \nHost: "},
+		{
+			input:  "",
+			method: http.MethodGet,
+			header: headers,
+			want:   "GET  \nHost: \ncontent-type: text/plain; charset=utf-8",
+		},
+		{
+			input:  "a",
+			method: http.MethodPost,
+			header: headers,
+			want:   "POST a \nHost: \ncontent-type: text/plain; charset=utf-8\n\n\n",
+		},
 	}
 	for _, test := range tests {
 		u := url.URL{Path: test.input}
-		request := http.Request{URL: &u}
+		request := http.Request{Method: test.method, URL: &u, Header: test.header}
 		got := FormatRequest(&request)
 		gotool.AssertEqual(t, got, test.want)
 	}


### PR DESCRIPTION
Инкремент 2. Разработать агент (HTTP-клиент) для сбора рантайм-метрик и их последующей отправки на сервер по протоколу HTTP. Инкремент 3. Используя любой внешний пакет (роутер или фреймворк), совместимый с net/http, перепишите ваш код. Инкремент 4. Добавить возможность конфигурировать сервис с помощью аргументов командной строки. Инкремент 5. Доработать агент, чтобы он мог изменять свои параметры запуска по умолчанию через переменные окружения. Доработать сервер, чтобы он мог изменять свои параметры запуска по умолчанию через переменные окружения.